### PR TITLE
Even more template fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
+          level: info
           working_directory: testdata
 
       # The check is expected to fail on the test data
@@ -57,6 +58,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
+          level: info
           working_directory: testdata
 
       # The check is expected to fail on the test data
@@ -94,6 +96,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
+          level: info
           working_directory: testdata
 
       # The check is expected to fail on the test data


### PR DESCRIPTION
As it can be seen in https://github.com/reviewdog/action-tflint/runs/463021043, the tests are marked as failed due to a GitHub annotation from the testing of the action.

This PR moves to `info` for the check in hopes of not failing the tests.