### PR TITLE
Customisable tflint version

### DIFF
--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -24,6 +24,7 @@ jobs:
           reporter: github-pr-check
           level: info
           working_directory: testdata_module
+          tflint_version: v0.23.0
 
       # The check is expected to fail on the test data
       - name: Check return codes

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ See [reviewdog documentation for exit codes](https://github.com/reviewdog/review
 Optional. Directory to run the action on, from the repo root.
 The default is `.` ( root of the repository).
 
+### `tflint_version`
+
+Optional. The tflint version to install and use.
+The default is `latest`.
+
 ### `flags`
 
 Optional. List of arguments to send to `tflint`.
@@ -123,6 +128,7 @@ jobs:
           reporter: github-pr-review # Optional. Change reporter
           fail_on_error: "true" # Optional. Fail action if errors are found
           filter_mode: "nofilter" # Optional. Check all files, not just the diff
+          tflint_version: "v0.24.0" # Optional. Custom version, instead of latest
           flags: "--module" # Optional. Add custom tflint flags
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,8 @@ runs:
       id: tflint
       shell: bash
       env:
+        # We may want to allow specifying reviewdog version as
+        # action's input, but let's start with hard coded latest stable version for reviewdog
         REVIEWDOG_VERSION: v0.11.0
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
       Directory to run the action on, from the repo root.
       Default is . ( root of the repository)
     default: '.'
+  tflint_version:
+    description: |
+      The tflint version to install and use.
+      Default is to use the latest release version.
+    default: 'latest'
   flags:
     description: |
       List of arguments to send to tflint
@@ -51,9 +56,6 @@ runs:
       id: tflint
       shell: bash
       env:
-        # We may want to allow specifying reviewdog and tflint version as
-        # action's input, but let's start with hard coded latest stable version for reviewdog
-        # and latest release for tflint
         REVIEWDOG_VERSION: v0.11.0
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
@@ -63,6 +65,7 @@ runs:
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
+        INPUT_TFLINT_VERSION: ${{ inputs.tflint_version }}
         INPUT_FLAGS: ${{ inputs.flags }}
 
 branding:

--- a/script.sh
+++ b/script.sh
@@ -10,10 +10,7 @@ curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.s
 echo '::endgroup::'
 
 echo '::group:: Installing tflint ... https://github.com/terraform-linters/tflint'
-curl -sfL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh > install_tflint_linux.sh
-chmod +x install_tflint_linux.sh
-TFLINT_VERSION="${INPUT_TFLINT_VERSION}" ./install_tflint_linux.sh
-rm install_tflint_linux.sh
+curl -sfL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | TFLINT_VERSION="${INPUT_TFLINT_VERSION}" bash
 echo '::endgroup::'
 
 

--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,10 @@ curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.s
 echo '::endgroup::'
 
 echo '::group:: Installing tflint ... https://github.com/terraform-linters/tflint'
-curl -L "$(curl -Ls https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" -o tflint.zip && unzip tflint.zip -d "${TEMP_PATH}" && rm tflint.zip
+curl -sfL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh > install_tflint_linux.sh
+chmod +x install_tflint_linux.sh
+TFLINT_VERSION="${INPUT_TFLINT_VERSION}" ./install_tflint_linux.sh
+rm install_tflint_linux.sh
 echo '::endgroup::'
 
 


### PR DESCRIPTION
Adding the option to use a custom `tflint` version. By default `latest` will continue to be used for backwards compatibility 🙂 

Closes https://github.com/reviewdog/action-tflint/issues/32