### PR TITLE
[GHES] Use GitHub URL from default env var

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -83,7 +83,7 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
 
   # shellcheck disable=SC2086
   TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" --format=checkstyle ${INPUT_FLAGS} . \
-    | "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
+    | GITHUB_API="$GITHUB_API_URL" "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
         -name="tflint" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \

--- a/script.sh
+++ b/script.sh
@@ -83,7 +83,7 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
 
   # shellcheck disable=SC2086
   TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" --format=checkstyle ${INPUT_FLAGS} . \
-    | GITHUB_API="$GITHUB_API_URL" "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
+    | GITHUB_API="${GITHUB_API_URL}/" "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
         -name="tflint" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \


### PR DESCRIPTION
Fixes https://github.com/reviewdog/action-tflint/issues/37

By default, GitHub sets the URL to the GitHub Server in [`GITHUB_API_URL`](https://docs.github.com/en/enterprise-server@3.0/actions/reference/environment-variables#default-environment-variables). For the hosted "github.com" that most people use, that is `https://api.github.com`. For GitHub Enterprise Server it may be something like `https://api.github.company.com`.

Reviewdog expects the URL in  [`GITHUB_API`](https://github.com/reviewdog/reviewdog#reporter-github-pullrequest-review-comment--reportergithub-pr-review). This PR connects the two variables together. 

~Unsolved question: should we also add an extra option to set `REVIEWDOG_INSECURE_SKIP_VERIFY`?~