### PR TITLE
take github_token from `github.token` by default according to README

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN'
     required: true
+    default: ${{ github.token }}
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'


### PR DESCRIPTION
README says about `github_token` as below:

> Default is ${{ github.token }}.

Actually, however, action.yml declares no default value for `github_token`.
See https://github.com/reviewdog/action-tflint/blob/d8e2e0716a08074125dde1bcac4994d9ff9662f9/action.yml#L6-L8

This pull request changes the `github_token`'s default value to `${{ github.token }}` like other reviewdog actions.