### PR TITLE
Add tflint Target Directory Parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
       Whether or not to run tflint --init prior to running scan [true,false]
       Default is `false`.
     default: 'false'
+  tflint_target_dir:
+    description: |
+      The target dir for the tflint command. This is the directory passed to tflint as opposed to working_directory which is the directory the command is executed from.
+      Default is . ( root of the repository)
+    default: '.'
   flags:
     description: |
       List of arguments to send to tflint
@@ -81,6 +86,7 @@ runs:
         INPUT_TFLINT_VERSION: ${{ inputs.tflint_version }}
         INPUT_TFLINT_RULESETS: ${{ inputs.tflint_rulesets }}
         INPUT_TFLINT_INIT: ${{ inputs.tflint_init }}
+        INPUT_TFLINT_TARGET_DIR: ${{ inputs.tflint_target_dir }}
         INPUT_FLAGS: ${{ inputs.flags }}
 
 branding:

--- a/script.sh
+++ b/script.sh
@@ -98,7 +98,7 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
   set +Eeuo pipefail
 
   # shellcheck disable=SC2086
-  TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" --format=checkstyle ${INPUT_FLAGS} . \
+  TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" --format=checkstyle ${INPUT_FLAGS} ${INPUT_TFLINT_TARGET_DIR} \
     | "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
         -name="tflint" \
         -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
Hey @Vlaaaaaaad and @haya14busa I want to add this additional parameter. For my user case I would like to have one .tflint.hcl file in the root of my repo but use that same configuration to check multiple sub directories in the repo. Currently working_directory doesn't work easily for this use case because tflint seems to look in the working directory for it's config and it would be harder to change the working dir and then use a flag to point back to the config in the repo root than to just run tflint from the root and point it to the sub module dirs.

Thanks.