### PR TITLE
chore: `::set-output` is deprecated

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -107,8 +107,8 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
         -filter-mode="${INPUT_FILTER_MODE}"
 
   tflint_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[1]}" exit_code=$?
-  echo "::set-output name=tflint-return-code::${tflint_return}"
-  echo "::set-output name=reviewdog-return-code::${reviewdog_return}"
+  echo "tflint-return-code=${tflint_return}" >> "${GITHUB_OUTPUT}"
+  echo "reviewdog-return-code=${reviewdog_return}" >> "${GITHUB_OUTPUT}"
 echo '::endgroup::'
 
 exit "${exit_code}"


### PR DESCRIPTION
When I use `reviewdog/action-tflint`, I got the following deprecation warning.

```
 Running tflint with reviewdog 🐶 ...
  reviewdog: this is not PullRequest build.
  Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

ref. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

So I fixed this.

This patch works on my repository and deprecation warning is gone.