### PR TITLE
fix: Pass GITHUB_TOKEN to tflint download - `curl (22) The requested URL returned error: 403`  

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -30,7 +30,7 @@ echo '::group::Preparing'
 
   if [[ -z "${INPUT_TFLINT_VERSION}" ]] || [[ "${INPUT_TFLINT_VERSION}" == "latest" ]]; then
     echo "Looking up the latest tflint version ..."
-    tflint_version=$(curl --silent --show-error --fail --location "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    tflint_version=$(curl -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" --silent --show-error --fail --location "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
   else
     tflint_version=${INPUT_TFLINT_VERSION}
   fi


### PR DESCRIPTION
Fix for https://github.com/reviewdog/action-tflint/issues/61

Pass the GITHUB_TOKEN to the `curl` downloading `tflint` from GitHub to "request the concurrency bucket is larger."