### PR TITLE
Fix tflint deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,7 +224,6 @@ jobs:
           reporter: github-pr-check
           level: info
           working_directory: tests/modules
-          tflint_version: v0.32.0
 
       # The check is expected to fail on the test data
       - name: Check return codes

--- a/script.sh
+++ b/script.sh
@@ -98,7 +98,7 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
   set +Eeuo pipefail
 
   # shellcheck disable=SC2086
-  TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" -c "${INPUT_TFLINT_CONFIG}" --format=checkstyle ${INPUT_FLAGS} ${INPUT_TFLINT_TARGET_DIR} \
+  TFLINT_PLUGIN_DIR=${TFLINT_PLUGIN_DIR} "${TFLINT_PATH}/tflint" -c "${INPUT_TFLINT_CONFIG}" --format=checkstyle ${INPUT_FLAGS} --chdir=${INPUT_TFLINT_TARGET_DIR} \
     | "${REVIEWDOG_PATH}/reviewdog" -f=checkstyle \
         -name="tflint" \
         -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
This PR aims to fix the use of [deprecated tflint cli syntax](https://github.com/terraform-linters/tflint/blob/master/CHANGELOG.md#0460-2023-04-09) which was causing our CI pipeline to fail when using this action.
![Screenshot 2023-05-16 at 15 38 24](https://github.com/reviewdog/action-tflint/assets/72092369/d6f4de49-2cb3-4a9b-a065-8eaf8e6c11e4)
