### PR TITLE
Add .tflint.hcl to test case directories and fix the process of getting arch

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -19,8 +19,8 @@ echo '::group::Preparing'
   unameArch="$(uname -m)"
   case "${unameArch}" in
     x86*)      arch=amd64;;
-    aarch64*)  arch=arm;;
-    arm64*)    arch=arm;;
+    aarch64*)  arch=arm64;;
+    arm64*)    arch=arm64;;
     *)         echo "Unsupported architecture: ${unameArch}" && exit 1
   esac
 

--- a/script.sh
+++ b/script.sh
@@ -20,6 +20,7 @@ echo '::group::Preparing'
   case "${unameArch}" in
     x86*)      arch=amd64;;
     aarch64*)  arch=arm;;
+    arm64*)    arch=arm;;
     *)         echo "Unsupported architecture: ${unameArch}" && exit 1
   esac
 

--- a/tests/modules/.tflint.hcl
+++ b/tests/modules/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/tests/reviewdog-reporters/.tflint.hcl
+++ b/tests/reviewdog-reporters/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}


### PR DESCRIPTION
https://github.com/reviewdog/action-tflint/actions/runs/9427989877/job/25972795210

```
Failed to load TFLint config; failed to load file: open .tflint.hcl: no such file or directory
```

https://github.com/reviewdog/action-tflint/actions/runs/9427989877/job/25972795602

```
Unsupported architecture: arm64
```

CI `Tests` fails.
Therefore, I add `.tflint.hcl` ( See https://github.com/terraform-linters/tflint?tab=readme-ov-file#getting-started ) to test case directories and I fix the process of getting `arch` so that `action-tflint` downloads `tflint_${os}_arm64.zip` if `uname -m` returns `aarch64` or `arm64`.