### PR TITLE
Replace default flags from --module to --call-module-type=all

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The default is `false`.
 
 Optional. List of arguments to send to `tflint`.
 For the output to be parsable by reviewdog [`--format=checkstyle` is enforced](./entrypoint.sh).
-The default is `--module`.
+The default is `--call-module-type=all`.
 
 ## Outputs
 
@@ -118,7 +118,7 @@ jobs:
         run: |
           brew install terraform
 
-      # Run init to get module code to be able to use `--module`
+      # Run init to get module code to be able to use `--call-module-type=all`
       - name: Terraform init
         run: |
           terraform init
@@ -140,7 +140,7 @@ jobs:
           filter_mode: "nofilter" # Optional. Check all files, not just the diff
           tflint_version: "v0.24.0" # Optional. Custom version, instead of latest
           tflint_rulesets: "azurerm google" # Optional. Extra official rulesets to install
-          flags: "--module" # Optional. Add custom tflint flags
+          flags: "--call-module-type=all" # Optional. Add custom tflint flags
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,8 @@ inputs:
     description: |
       List of arguments to send to tflint
       For the output to be parsable by reviewdog --format=checkstyle is enforced
-      Default is --module.
-    default: '--module'
+      Default is --call-module-type=all.
+    default: '--call-module-type=all'
 
 outputs:
   tflint-return-code:


### PR DESCRIPTION
https://github.com/reviewdog/action-tflint/actions/runs/10328074459/job/28594149497

```
WARNING: --module is deprecated. Use --call-module-type=all instead.
```

`--module` has been deprecated.
Therefore, I replace default `flags` from `--module` to `--call-module-type=all`.