### PR TITLE
Update reviewdog and add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ See [reviewdog documentation for filter mode](https://github.com/reviewdog/revie
 
 ### `fail_level`
 
-Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Optional. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
 Possible values: [`none`, `any`, `info`, `warning`, `error`]
 Default is `none`.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,15 @@ The default is `added`.
 
 See [reviewdog documentation for filter mode](https://github.com/reviewdog/reviewdog/tree/master#filter-mode) for details.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Optional. Exit code for reviewdog when errors are found [`true`,`false`].
 
 The default is `false`.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           working_directory: "testdata" # Optional. Change working directory
           reporter: github-pr-review # Optional. Change reporter
-          fail_on_error: "true" # Optional. Fail action if errors are found
+          fail_level: "any" # Optional. Fail action if it finds at least 1 issue with severity greater than or equal to the given level.
           filter_mode: "nofilter" # Optional. Check all files, not just the diff
           tflint_version: "v0.24.0" # Optional. Custom version, instead of latest
           tflint_rulesets: "azurerm google" # Optional. Extra official rulesets to install

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,18 @@ inputs:
       Filtering for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   working_directory:
     description: |
@@ -86,6 +94,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_TFLINT_VERSION: ${{ inputs.tflint_version }}

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
       env:
         # We may want to allow specifying reviewdog version as
         #  action's input, but let's start with hard coded latest stable version for reviewdog
-        REVIEWDOG_VERSION: v0.17.5
+        REVIEWDOG_VERSION: v0.20.2
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/script.sh
+++ b/script.sh
@@ -114,6 +114,7 @@ echo '::group:: Running tflint with reviewdog 🐶 ...'
         -name="tflint" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -filter-mode="${INPUT_FILTER_MODE}"
 


### PR DESCRIPTION
Based on https://github.com/reviewdog/action-tflint/pull/91, I update reviewdog.

In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.