### PR TITLE
Add reviewdog_github_api_token input

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The default is `--call-module-type=all`.
 ### `reviewdog_github_api_token`
 
 Optional. The value of REVIEWDOG_GITHUB_API_TOKEN environment variable.
-The default is `${{ github.token }}`.
+If value is empty string, use `github_token` value.
+The default is `''`.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ Optional. List of arguments to send to `tflint`.
 For the output to be parsable by reviewdog [`--format=checkstyle` is enforced](./entrypoint.sh).
 The default is `--call-module-type=all`.
 
+### `reviewdog_github_api_token`
+
+Optional. The value of REVIEWDOG_GITHUB_API_TOKEN environment variable.
+The default is `${{ github.token }}`.
+
 ## Outputs
 
 ## `tflint-return-code`

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     default: '--call-module-type=all'
   reviewdog_github_api_token:
     description: 'REVIEWDOG_GITHUB_API_TOKEN'
-    default: ${{ github.token }}
+    default: ''
 
 outputs:
   tflint-return-code:

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
       For the output to be parsable by reviewdog --format=checkstyle is enforced
       Default is --call-module-type=all.
     default: '--call-module-type=all'
+  reviewdog_github_api_token:
+    description: 'REVIEWDOG_GITHUB_API_TOKEN'
+    default: ${{ github.token }}
 
 outputs:
   tflint-return-code:
@@ -104,6 +107,7 @@ runs:
         INPUT_TFLINT_TARGET_DIR: ${{ inputs.tflint_target_dir }}
         INPUT_TFLINT_CONFIG: ${{ inputs.tflint_config }}
         INPUT_FLAGS: ${{ inputs.flags }}
+        INPUT_REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.reviewdog_github_api_token }}
 
 branding:
   icon: 'edit'

--- a/script.sh
+++ b/script.sh
@@ -93,7 +93,7 @@ echo '::endgroup::'
 
 
 echo '::group:: Running tflint with reviewdog 🐶 ...'
-  export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+  export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_REVIEWDOG_GITHUB_API_TOKEN}"
 
   # Allow failures now, as reviewdog handles them
   set +Eeuo pipefail

--- a/script.sh
+++ b/script.sh
@@ -93,7 +93,7 @@ echo '::endgroup::'
 
 
 echo '::group:: Running tflint with reviewdog 🐶 ...'
-  export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_REVIEWDOG_GITHUB_API_TOKEN}"
+  export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_REVIEWDOG_GITHUB_API_TOKEN:-${INPUT_GITHUB_TOKEN}}"
 
   # Allow failures now, as reviewdog handles them
   set +Eeuo pipefail


### PR DESCRIPTION
I get the following error when using the Github enterprise server.

```
 Running tflint with reviewdog 🐶 ...
  reviewdog: fail to get diff: GET https://github.enterprise.server/api/v3/repos/owner/repo/pulls/1: 401 Bad credentials []
```

Added support for setting api token on api.github.com and api token on github enterprise server separately.